### PR TITLE
GA4（Google Analytics 4）計測コードと環境変数サンプルを追加

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,44 @@
+# Contentful API Keys
+# Get your keys from: https://app.contentful.com/spaces/[SPACE_ID]/api/keys
+CONTENTFUL_SPACE_ID=your_contentful_space_id_here
+CONTENTFUL_CDA_ACCESS_TOKEN=your_contentful_cda_access_token_here
+CONTENTFUL_CPA_ACCESS_TOKEN=your_contentful_cpa_access_token_here
+CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN=your_contentful_management_api_access_token_here
+CONTENTFUL_ORGANIZATION_ID=your_contentful_organization_id_here
+
+Redis Upstash Secrets
+# Get your Redis credentials from: https://upstash.com/
+UPSTASH_REDIS_REST_URL=https://your-redis-url.upstash.io
+UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_rest_token_here
+
+# NextAuth Secret
+# Generate with: npx auth secret
+# Read more: https://cli.authjs.dev
+AUTH_SECRET="your_nextauth_secret_here"
+
+# Google OAuth Configuration
+# Get your credentials from: https://console.developers.google.com/
+GOOGLE_CLIENT_ID=your_google_client_id_here.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your_google_client_secret_here
+
+# MongoDB Configuration
+# Get your connection string from: https://cloud.mongodb.com/
+MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/?retryWrites=true&w=majority&appName=your_app_name
+
+# Mailgun Configuration
+# Get your credentials from: https://app.mailgun.com/
+MAILGUN_API_KEY=your_mailgun_api_key_here
+MAILGUN_DOMAIN=your_mailgun_domain_here.mailgun.org
+FROM_EMAIL=your_from_email@your_domain.com
+TO_EMAIL=your_to_email@example.com
+
 # Chromatic Project Token
 # Get your project token from: https://www.chromatic.com/manage
 # Add this to your .env.local file for local development
 CHROMATIC_PROJECT_TOKEN=your_chromatic_project_token_here
 
 # Example: CHROMATIC_PROJECT_TOKEN=chpt_xxxxxxxxxxxxxxx
+
+# Google Analytics 4 Measurement ID
+# Get your measurement ID from: https://analytics.google.com/
+NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import type { Metadata } from 'next'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages, getTranslations } from 'next-intl/server'
 import { notFound } from 'next/navigation'
+import Script from 'next/script'
 import type { FC } from 'react'
 
 export const generateMetadata = async ({ params }: Props): Promise<Metadata> => {
@@ -123,6 +124,27 @@ const LocaleLayout: FC<Props> = async ({ children, params }) => {
   return (
     <html lang={locale}>
       <body className={classNames(zain.className, 'antialiased')}>
+        {/* Google Analytics 4 (GA4) Tracking Code */}
+        <Script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID}`}
+          strategy="afterInteractive" // ページのインタラクティブな要素の後にロード
+        />
+        <Script
+          id="google-analytics-config" // 一意のID
+          strategy="afterInteractive" // ページのインタラクティブな要素の後にロード
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID}', {
+                page_path: window.location.pathname,
+              });
+            `
+          }}
+        />
+        {/* GA4 Tracking Code End  */}
         <AuthProvider>
           <NextIntlClientProvider messages={messages}>
             <LayoutWrapper


### PR DESCRIPTION
## 概要
- GA4（Google Analytics 4）の計測コードを`layout.tsx`に追加
- `.env.local.example`にGA4用の環境変数サンプルを追加

## 変更内容
- `src/app/[locale]/layout.tsx`にGA4のScriptタグを追加
- `.env.local.example`に`NEXT_PUBLIC_GA4_MEASUREMENT_ID`を追加

## 動作確認
- 計測タグが正しく挿入されていること
- 環境変数サンプルが最新になっていること

## その他
- gitmojiルール・コミット済み
- レビューよろしく！