### PR TITLE
Replace max-w-screen-xxs with explicit width values

### DIFF
--- a/src/app/ui/articles/layout/article-layout.tsx
+++ b/src/app/ui/articles/layout/article-layout.tsx
@@ -21,7 +21,7 @@ export const ArticleLayout: FC<Props> = ({ children, locale, breadcrumbs, profil
       <div
         className={classNames(
           'w-full flex flex-col gap-1 ',
-          'max-w-screen-xxs',
+          'max-w-[360px]',
           'xs:max-w-screen-xs',
           'semi-sm:max-w-screen-semi-sm',
           'sm:max-w-screen-sm',

--- a/src/app/ui/components/organisms/blog-post/presenter.tsx
+++ b/src/app/ui/components/organisms/blog-post/presenter.tsx
@@ -31,7 +31,7 @@ export const BlogPost: FC<Props> = ({ slug, blogPost, views, relatedPosts, relat
     <ReportView slug={slug} />
     <div
       className={classNames(
-        'flex flex-col gap-1 max-w-screen-xxs',
+        'flex flex-col gap-1 max-w-[360px]',
         'xs:max-w-screen-xs',
         'semi-sm:max-w-screen-semi-sm',
         'sm:max-w-screen-sm',


### PR DESCRIPTION
## Summary
• Replace `max-w-screen-xxs` with explicit `max-w-[360px]` in article layout and blog post components
• Improves consistency and clarity of responsive design implementation

## Test plan
- [ ] Verify article layout displays correctly on mobile devices
- [ ] Confirm blog post layout maintains proper width constraints
- [ ] Check responsive behavior across different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)