### PR TITLE
🐛 Fix popular articles ranking instability

### DIFF
--- a/src/app/ui/popular-blog-posts/container.tsx
+++ b/src/app/ui/popular-blog-posts/container.tsx
@@ -1,9 +1,9 @@
 import { createApolloClient } from '@/apolloClient'
 import { PopularBlogPosts } from '@/app/ui/popular-blog-posts/presenter'
-import { type LANGUAGE, LOCALE_CODE_MAP } from '@/constants'
-import type { GetBlogPostsQuery, GetBlogPostsQueryVariables, PageBlogPost } from '@/generated/graphql'
-import { GET_BLOG_POSTS_QUERY } from '@/graphql/query'
-import { getMultiplePageViews } from '@/utils/redis'
+import { type LANGUAGE } from '@/constants'
+import type { GetBlogPostsBySlugsQuery, GetBlogPostsBySlugsQueryVariables, PageBlogPost } from '@/generated/graphql'
+import { GET_BLOG_POSTS_BY_SLUGS_QUERY } from '@/graphql/query'
+import { getAllPageViews } from '@/utils/redis'
 import { getTranslations } from 'next-intl/server'
 import type { FC } from 'react'
 
@@ -15,41 +15,37 @@ type Props = {
 
 export const PopularBlogPostsContainer: FC<Props> = async ({ locale, limit = 10, skip = 0 }) => {
   const t = await getTranslations({ locale })
+
+  // Redisから全記事の閲覧数を取得（降順でソート済み）
+  const allPageViews = await getAllPageViews()
+
+  if (allPageViews.length === 0) return null
+
+  // 上位記事のslugを取得（limitを適用）
+  const topSlugs = allPageViews.slice(skip, skip + limit).map((item) => item.slug)
+
+  if (topSlugs.length === 0) return null
+
+  // GraphQLで記事詳細を取得
   const client = createApolloClient()
-  const { data } = await client.query<GetBlogPostsQuery, GetBlogPostsQueryVariables>({
-    query: GET_BLOG_POSTS_QUERY,
+  const { data } = await client.query<GetBlogPostsBySlugsQuery, GetBlogPostsBySlugsQueryVariables>({
+    query: GET_BLOG_POSTS_BY_SLUGS_QUERY,
     variables: {
-      locale: LOCALE_CODE_MAP[locale],
-      skip,
-      limit
+      slugs: topSlugs
     }
   })
+
   const blogPosts = data.pageBlogPostCollection?.items.filter((post): post is PageBlogPost => post !== null)
   if (!blogPosts || blogPosts.length === 0) return null
 
-  // 全記事のslugを取得
-  const slugs = blogPosts.map((post) => post.slug).filter((slug): slug is string => slug !== null)
+  // 閲覧数順でソートし、viewCountプロパティを追加
+  const viewsMap = Object.fromEntries(allPageViews.map((item) => [item.slug, item.views]))
+  const sortedBlogPosts = blogPosts
+    .map((post: PageBlogPost) => ({
+      ...post,
+      viewCount: viewsMap[post.slug || ''] ?? 0
+    }))
+    .sort((a, b) => b.viewCount - a.viewCount)
 
-  // Redisから閲覧数を一括取得
-  const viewsData = await getMultiplePageViews(slugs)
-  // 閲覧数に基づいて記事をソートし、viewCountプロパティを追加
-  const sortedBlogPosts = [...blogPosts]
-    .map((post: PageBlogPost) => {
-      if (post.slug) {
-        return {
-          ...post,
-          viewCount: viewsData[post.slug] ?? 0
-        }
-      }
-      return post
-    })
-    .sort((a, b) => {
-      if (!a.slug || !b.slug) return 0
-      return ((b as PageBlogPost & { viewCount: number }).viewCount ?? 0) - ((a as PageBlogPost & { viewCount: number }).viewCount ?? 0) // 降順
-    })
-
-  // 上位10件を取得
-  const topTenPosts = sortedBlogPosts.slice(0, 10) as (PageBlogPost & { viewCount: number })[]
-
-  return <PopularBlogPosts articles={topTenPosts} title={t('PopularArticleList.title')} viewCountText={t('Article.views')} />
+  return <PopularBlogPosts articles={sortedBlogPosts} title={t('PopularArticleList.title')} viewCountText={t('Article.views')} />
 }


### PR DESCRIPTION
## Summary
• Changed popular articles from GraphQL-first to Redis-first approach
• Added getAllPageViews() function to fetch all page views from Redis
• Modified PopularBlogPostsContainer to sort by actual view counts
• Ensures consistent ranking regardless of new article publications

## Test plan
- [x] Verify popular articles display correctly
- [x] Check that rankings remain stable when new articles are published
- [x] Confirm view counts are accurate
- [x] Test pagination with skip/limit parameters

🤖 Generated with [Claude Code](https://claude.ai/code)